### PR TITLE
Modified linear_regression_l2.py to have more accurate description

### DIFF
--- a/labs/01/linear_regression_l2.py
+++ b/labs/01/linear_regression_l2.py
@@ -21,7 +21,8 @@ if __name__ == "__main__":
     # `test_size=args.test_size` and `random_state=args.seed`.
 
     # TODO: Using sklearn.linear_model.Ridge, fit the train set using
-    # L2 regularization, employing lambdas from 0 to 100 with a step size 0.1.
+    # L2 regularization, employing alpha (according to Ridge constructor documentation) 
+    # from 0 to 100 with a step size 0.1.
     #
     # For every model, compute the root mean squared error, and print out the
     # lambda producing lowest test error and the test error itself.


### PR DESCRIPTION
In slides you have lambda / 2 in regularization formula. In linear_regression_l2 you write in comment to iterate over lambdas, although according to your slides you mean iterate over lambda / 2 (https://ufal.mff.cuni.cz/~straka/courses/npfl129/1920/slides/?01#63).
Due to that I changed comment to use alpha instead. Alpha is used in Ridge constructor documentation (https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html).