### PR TITLE
Add slide for explicit bias vs padding w/ 1s

### DIFF
--- a/slides/01/01.md
+++ b/slides/01/01.md
@@ -196,6 +196,51 @@ $→x^T→w$, where the role of a bias is accomplished by the last weight.
 Therefore, when we say “weights”, we usually mean both weights and biases.
 
 ---
+# Separate Bias vs. Padding $⇉X$ with $1$s
+
+Using an explicit bias term in the form of $f(x) = →w^T →x + b$.
+$$
+\begin{bmatrix}
+x_{11} & x_{12} \\
+x_{21} & x_{22} \\
+\quad\qquad \vdots \\
+x_{n1} & x_{n2} \\
+\end{bmatrix} \cdot
+\begin{bmatrix}
+w_1 \\ w_2
+\end{bmatrix} + b
+=
+\begin{bmatrix}
+w_1 x_{11} + w_2 x_{12} + b \\
+w_1 x_{21} + w_2 x_{22} + b \\
+\vdots \\
+w_1 x_{n1} + w_2 x_{n2} + b
+\end{bmatrix}
+$$
+
+~~~
+With extra $1$ padding in $⇉X$ and an additional $w_0$ weight representing the
+bias.
+$$
+\begin{bmatrix}
+1 & x_{11} & x_{12} \\
+1 & x_{21} & x_{22} \\
+& \vdots & \\
+1 & x_{n1} & x_{n2} \\
+\end{bmatrix} \cdot
+\begin{bmatrix}
+w_0 \\ w_1 \\ w_2
+\end{bmatrix}
+=
+\begin{bmatrix}
+w_0 \cdot 1 + w_1 x_{11} + w_2 x_{12} \\
+w_0 \cdot 1 + w_1 x_{21} + w_2 x_{22} \\
+\vdots \\
+w_0 \cdot 1 + w_1 x_{n1} + w_2 x_{n2}
+\end{bmatrix}
+$$
+
+---
 # Linear Regression
 
 Assume we have a dataset of $N$ input values $→x_1, …, →x_N$ and targets


### PR DESCRIPTION
We should probably name the slide better, but I can't think of anything right now. I tried making the matrix more general first with `$x_{11}, x_{12}, \cdots, x_{1m}$` but it just looked more confusing when written out after multiplication, so only ended up keeping two columns.

Also note sure if `$w_0$` shouldn't be placed on the right, but then it probably shouldn't be named `$w_0$` but `$w_3$`, but then it's not that obvious what it is. Though placing the bias on the left in the first equation doesn't look ideal either.