### PR TITLE
condition for incorrectly classified example

### DIFF
--- a/slides/02/02.md
+++ b/slides/02/02.md
@@ -439,7 +439,7 @@ The perceptron algorithm was invented by Rosenblat in 1958.
 - until all examples are classified correctly:
   - for $i$ in $1, …, N$:
     - $y ← →w^T→x_i$
-    - if $t_i y < 0$ (incorrectly classified example):
+    - if $t_i y <= 0$ (incorrectly classified example):
       - $→w ← →w + t_i →x_i$
 </div>
 
@@ -455,14 +455,14 @@ Consider the main part of the perceptron algorithm:
 <div class="algorithm">
 
   - $y ← →w^T→x_i$
-  - if $t_i y < 0$ (incorrectly classified example):
+  - if $t_i y <= 0$ (incorrectly classified example):
     - $→w ← →w + t_i →x_i$
 </div>
 
 ~~~
 We can derive the algorithm using on-line gradient descent, using
 the following loss function
-$$L(f(→x; →w), t) ≝ \begin{cases} -t →x^T →w & \textrm{if~}t →x^T →w < 0 \\ 0 & \textrm{otherwise}\end{cases}
+$$L(f(→x; →w), t) ≝ \begin{cases} -t →x^T →w & \textrm{if~}t →x^T →w <= 0 \\ 0 & \textrm{otherwise}\end{cases}
   = \max(0, -t→x^T →w) = \ReLU(-t→x^T →w).$$
 
 ~~~


### PR DESCRIPTION
Shouldn't it be `if t_i*y <= 0` (not just <), when deciding whether to update weights. Because in the beginning we initialize weights with zeros, so y would be 0.