### PR TITLE
Update lecture02.md

### DIFF
--- a/lectures/lecture02.md
+++ b/lectures/lecture02.md
@@ -1,11 +1,11 @@
 ### Lecture: 2. Linear Regression II, SGD
 #### Date: Oct 12
 #### Slides: https://ufal.mff.cuni.cz/~straka/courses/npfl129/2021/slides/?02
-#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl129/2021/slides.pdf/npfl129-02.pdf,PDF Slides
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-czech.mp4,CZ Lecture
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-english.mp4,EN Lecture
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-czech.practicals.mp4,CZ Practicals
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-english.practicals.mp4,EN Practicals
+#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl129/2021/slides.pdf/npfl129-02.pdf ,PDF Slides
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-czech.mp4 ,CZ Lecture
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-english.mp4 ,EN Lecture
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-czech.practicals.mp4 ,CZ Practicals
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2021/npfl129-02-english.practicals.mp4 ,EN Practicals
 #### Lecture assignment: linear_regression_l2
 #### Lecture assignment: linear_regression_sgd
 #### Lecture assignment: feature_engineering


### PR DESCRIPTION
Fix ",PDF", ",CZ" and ",EN" being copied into the url when clicked