### PR TITLE
Fix lowercase t in dot product

### DIFF
--- a/slides/03/03.md
+++ b/slides/03/03.md
@@ -453,7 +453,7 @@ handle also more than two classes, which we will see shortly.
 Logistic regression employs the following parametrization of the conditional
 class probabilities:
 $$\begin{aligned}
-  P(C_1 | →x) &= σ(→x^t →w + →b) \\
+  P(C_1 | →x) &= σ(→x^T →w + →b) \\
   P(C_0 | →x) &= 1 - P(C_1 | →x),
 \end{aligned}$$
 where $σ$ is a **sigmoid function**


### PR DESCRIPTION
The T in the superscript of the dot product should probably be uppercase.