### PR TITLE
Make it clear to not pass modified `target` as `stratify` arg

### DIFF
--- a/labs/04/softmax_classification_sgd.py
+++ b/labs/04/softmax_classification_sgd.py
@@ -31,6 +31,9 @@ def main(args):
     # Split the dataset into a train set and a test set.
     # Use `sklearn.model_selection.train_test_split` method call, passing
     # arguments `test_size=args.test_size, random_state=args.seed`.
+    #
+    # Argument `stratify` splits the dataset with equal distribution of target classes in both parts,
+    # be careful to not modify the variable passed into that argument.
     train_data, test_data, train_target, test_target = sklearn.model_selection.train_test_split(
         data, target, stratify=target, test_size=args.test_size, random_state=args.seed)
 


### PR DESCRIPTION
Otherwise it leads to a silent fail when `target` is transformed into one-hot vectors -- everything works fine but data are permuted differently.