### PR TITLE
Fix typo

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -282,7 +282,7 @@ However, the variances are usually smoothed (increased) by a given constant $α$
 to avoid too sharp distributions.
 
 ~~~
-- The default value of $α$ in Scikit-learn is $10^9$ times the largest variance
+- The default value of $α$ in Scikit-learn is $10^-9$ times the largest variance
   of all features.
 
 ~~~


### PR DESCRIPTION
This most likely should be 10^-9 as per sklearn source code.