### PR TITLE
Kernel notation

### DIFF
--- a/slides/06/06.md
+++ b/slides/06/06.md
@@ -52,12 +52,12 @@ We can formulate an alternative linear regression algorithm (a so-called
 **Input**: Dataset ($⇉X = \{→x_1, →x_2, …, →x_N\} ∈ ℝ^{N×D}$, $→t ∈ ℝ^N$), learning rate $α ∈ ℝ^+$.<br>
 
 - Set $β_i ← 0$
-- Compute all values $K(→x_i, →x_j) = φ(→x_i)^T φ(→x_j)$
+- Compute all values $K_{ij} = φ(→x_i)^T φ(→x_j)$
 - Repeat until convergence
   - Sample a batch $→b$ (usually by generating a random permutation and splitting it)
   - Simultaneously for all $i ∈ →b$ (the $β_j$ on the right side must
     not be modified during the batch update):
-    - $β_i ← β_i + \frac{α}{|→b|}\Big(t_i - ∑\nolimits_j β_j K(→x_i, →x_j)\Big)$
+    - $β_i ← β_i + \frac{α}{|→b|}\Big(t_i - ∑\nolimits_j β_j K_{ij}\Big)$
 </div>
 
 ~~~


### PR DESCRIPTION
It was said at the lecture, that in the algorithm, the kernel K should be writen with indices as a matrix, not as a function K(x_i, x_j).