### PR TITLE
Fixed typo in Lecture 5 slides

### DIFF
--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -336,7 +336,7 @@ In the ROC curve, we consider two measures of a binary classifier under changing
 threshold:
 - **true positive rate** or **sensitivity** (probability of detection):
   $\frac{\TP}{\textrm{target positives}} = \frac{\TP}{\TP + \FN}$;
-- **false positive rate** of **1-specificity** (probability of false alarm):
+- **false positive rate** or **1-specificity** (probability of false alarm):
   $\frac{\FP}{\textrm{target negatives}} = \frac{\FP}{\FP + \TN}$;
 
 ![w=50%](roc_pr.png)![w=70%,mw=50%,h=center](roc_curve.svgz)


### PR DESCRIPTION
Changed "of" to "or" in the description of the False Positive Rate of the ROC curve