### PR TITLE
Fix a few typos

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -19,7 +19,7 @@ handle also more than two classes, which we will see shortly.
 Logistic regression employs the following parametrization of the conditional
 class probabilities:
 $$\begin{aligned}
-  p(C_1 | →x) &= σ(→x^t →w + b) \\
+  p(C_1 | →x) &= σ(→x^T →w + b) \\
   p(C_0 | →x) &= 1 - p(C_1 | →x),
 \end{aligned}$$
 

--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -307,7 +307,7 @@ threshold, the **area under curve** (AUC) is sometimes used as a metric.
 
 To extend $F_1$-score to multiclass classification, we expect one of the classes
 to be _negative_ and the others _different kinds of positive_. For each of the
-possitive classes, we compute the same confusion matrix as in the binary case
+positive classes, we compute the same confusion matrix as in the binary case
 (considering all other labels as negative ones), and then combine the results
 in one of the following ways:
 
@@ -320,7 +320,7 @@ in one of the following ways:
 ~~~
 - **macro-averaged** $F_1$ (or just **macro** $F_1$): we first compute the
   $F_1$-scores of the individual binary classifications and then compute
-  an unweighted average (therefore, the frequence of the classes is ignored).
+  an unweighted average (therefore, the frequency of the classes is ignored).
 
 ---
 section: ROC

--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -63,7 +63,7 @@ of the RBF kernel in parametric models like logistic regression or MLP.
 ~~~
 Generally, these methods define a mapping $→ψ:ℝ^D → ℝ^M$, generating $M$
 features from a given input example, such that
-$$K(→x, →z) ≈ →ψ(→x)^T →ψ(→z) = ∑_m →ψ_m(→x)^T →ψ_m(→z).$$
+$$K(→x, →z) ≈ →ψ(→x)^T →ψ(→z) = ∑_m →ψ_m(→x) →ψ_m(→z).$$
 
 ~~~
 For a given example $→x$, the features $→ψ(→x)$ are then used as input to

--- a/slides/13/13.md
+++ b/slides/13/13.md
@@ -426,7 +426,7 @@ model on a more difficult test set.
 ~~~
 Instead, we perform a paired bootstrap test. Our alternative hypothesis is that
 the mean of the model performance differences is larger than zero, and the null
-hypothesis is that it is less or equal to zero. We than repeatedly sample a test
+hypothesis is that it is less or equal to zero. We then repeatedly sample a test
 set with repetition and compute the difference of the model performances on the
 sampled test set, obtaining a distribution of differences _under the true distribution_.
 


### PR DESCRIPTION
Hi,
I fixed a few things I noticed during my preparation for the exam.

Additionally,
*   I think the softmax gradient should be `x * (a(y(x)) - 1_t)` assuming the right operand is a row vector
![image](https://user-images.githubusercontent.com/36577287/104857094-7ad71280-5916-11eb-8d67-6e9dc7d1781e.png)
*   Does the text below suggest we only consider `K-1` one-vs-all classifiers?
![image](https://user-images.githubusercontent.com/36577287/104857186-f638c400-5916-11eb-8e7a-662b1dad6b2f.png)
