### PR TITLE
Fix typos and few changes

### DIFF
--- a/slides/02/02.md
+++ b/slides/02/02.md
@@ -186,7 +186,7 @@ $$⇉V_r^T →w = ⇉Σ_r^{-1} ⇉U_r^T →t.$$
 class: dbend
 # SVD Solution of Linear Regression
 
-We have $⇉V_r^T →w = ⇉Σ_r^{-1} ⇉U_r^T →t$. If he original matrix $⇉X^T ⇉X$ was
+We have $⇉V_r^T →w = ⇉Σ_r^{-1} ⇉U_r^T →t$. If the original matrix $⇉X^T ⇉X$ was
 regular, then $r=D$ and $⇉V_r$ is a square regular orthogonal matrix, in which case
 $$→w = ⇉V_r ⇉Σ_r^{-1} ⇉U_r^T →t.$$
 

--- a/slides/03/03.md
+++ b/slides/03/03.md
@@ -175,7 +175,7 @@ class: dbend
 # Proof of Perceptron Convergence
 
 Assume that the maximum norm of any training example $\|→x\|$ is bounded by $R$,
-and that $γ$ is the minimum margin of $→w_*$, so $t →x^T w_* ≥ γ.$
+and that $γ$ is the minimum margin of $→w_*$, so $t →x^T →w_* ≥ γ.$
 
 ~~~
 First consider the dot product of $→w_*$ and $→w_k$:

--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -424,7 +424,7 @@ The multilayer perceptron can be trained using an SGD algorithm:
   where $M$ is the size of the layer computed by the corresponding edge
   - set biases to 0
 - until convergence (or until patience is over), process batch of $N$ examples:
-  - $g ← ∇_→w \frac{1}{N} ∑_j -\log p(t_j | →x_j; →w)$
+  - $→g ← ∇_→w \frac{1}{N} ∑_j -\log p(t_j | →x_j; →w)$
   - $→w ← →w - α→g$
 </div>
 

--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -444,7 +444,7 @@ should proceed gradually:
 - first compute $\frac{∂L}{∂→y}$,
 
 ~~~
-- then compute $\frac{∂→y}{∂→y_\mathit{in}}$, where $y_\mathit{in}$ are the
+- then compute $\frac{∂→y}{∂→y_\mathit{in}}$, where $→y_\mathit{in}$ are the
   inputs to the output layer (i.e., before applying activation function $a$;
   in other words, $→y = a(→y_\mathit{in})$),
 ~~~

--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -200,7 +200,7 @@ matrix $⇉W$ and maybe a bias vector $→b$).
 
 - $→w ← 0$
 - until convergence (or until patience is over), process batch of $N$ examples:
-  - $g ← \tfrac{1}{N} ∑_i ∇_→w -\log(p(C_{t_i} | →x_i; →w))$
+  - $→g ← \tfrac{1}{N} ∑_i ∇_→w -\log(p(C_{t_i} | →x_i; →w))$
   - $→w ← →w - α→g$
 </div>
 

--- a/slides/06/06.md
+++ b/slides/06/06.md
@@ -87,7 +87,7 @@ section: Kernels
 # Kernel Trick
 
 A single SGD update of all $β_i$ then takes $𝓞(N^2)$, given that we can
-evaluate scalar dot product of $φ(→x_i)^T φ(→x_j)$ quickly.
+evaluate scalar dot product of $φ(→x)^T φ(→z)$ quickly.
 
 ~~~
 $$\begin{aligned}


### PR DESCRIPTION
Fixed a typo in "If he original matrix" to "If the original matrix", not bold vectors to bold and renamed misleading vectors.