### PR TITLE
Fixed: Running cloned template results in error

### DIFF
--- a/labs/01/linear_regression_manual.py
+++ b/labs/01/linear_regression_manual.py
@@ -41,4 +41,4 @@ def main(args: argparse.Namespace):
 if __name__ == "__main__":
     args = parser.parse_args([] if "__file__" not in globals() else None)
     rmse = main(args)
-    print("{:.2f}".format(rmse))
+    if rmse: print("{:.2f}".format(rmse))


### PR DESCRIPTION
When template linear_regression_manual is run it ends up with an error.
IMO This is not convenient especially when advicing to add print to
learn about dataset.

Error is caused by calling format on None. Fixed by adding a check.

To be honest, mostly I want to learn how to contribute to break the
entry barrier and ease up contributing later on.