### PR TITLE
Updated links to be click-through

### DIFF
--- a/lectures/lecture01.md
+++ b/lectures/lecture01.md
@@ -1,11 +1,11 @@
 ### Lecture: 1. Introduction to Machine Learning
 #### Date: Oct 04
 #### Slides: https://ufal.mff.cuni.cz/~straka/courses/npfl129/2122/slides/?01
-#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl129/2122/slides.pdf/npfl129-01.pdf,PDF Slides
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-czech.mp4,CZ Lecture
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-english.mp4,EN Lecture
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-czech.practicals.mp4,CZ Practicals
-#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-english.practicals.mp4,EN Practicals
+#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl129/2122/slides.pdf/npfl129-01.pdf, PDF Slides
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-czech.mp4, CZ Lecture
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-english.mp4, EN Lecture
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-czech.practicals.mp4, CZ Practicals
+#### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl129/2122/npfl129-01-english.practicals.mp4, EN Practicals
 #### Questions: #lecture_1_questions
 #### Lecture assignment: linear_regression_manual
 #### Lecture assignment: linear_regression_features


### PR DESCRIPTION
I propose slight changes in syntax so that the links to video recordings are click-through (original version was corrupted as the "," without a space preceding it concatenated letters not intended as part of the link, which broke it all).

Thank you so much for the recordings, they are awesome!