### PR TITLE
Add type hints for return values

### DIFF
--- a/labs/02/rental_competition.py
+++ b/labs/02/rental_competition.py
@@ -3,6 +3,7 @@ import argparse
 import lzma
 import os
 import pickle
+import typing
 import urllib.request
 
 import numpy as np
@@ -47,7 +48,7 @@ parser.add_argument("--seed", default=42, type=int, help="Random seed")
 # For these and any other arguments you add, ReCodEx will keep your default value.
 parser.add_argument("--model_path", default="rental_competition.model", type=str, help="Model path")
 
-def main(args: argparse.Namespace):
+def main(args: argparse.Namespace) -> typing.Union[None, np.ndarray]:
     if args.predict is None:
         # We are training a model.
         np.random.seed(args.seed)


### PR DESCRIPTION
I've noticed that you have been specifying type hints for the `main()` function in all of the templates so far. I have added the `typing.Union[None, np.ndarray]` which takes care of both possible return types.

Unfortunately, this requires another import, but starting from Python 3.10 (which you will probably use in the next school year), it will be possible to use `def main(...) -> None | np.ndarray` without any import.