### PR TITLE
Change linear combination to convex

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -228,7 +228,7 @@ convex (and therefore connected).
 To see this, consider $→x_A$ and $→x_B$ in the same decision region $R_k$.
 
 ~~~
-Any point $→x$ lying on the line connecting them is their linear combination,
+Any point $→x$ lying on the line connecting them is their convex combination,
 $→x = λ→x_A + (1-λ)→x_B$,
 ~~~
 and from the linearity of $→ȳ(→x) = →x^T ⇉W$ it follows that


### PR DESCRIPTION
I believe that "convex combination" should be used here as we are talking only about the line segment between the points, not the whole line.

(to be precise the "line" should be changed to "line segment", but I guess it's an understandable simplification)