### PR TITLE
Slides 07 | Fixed typo

### DIFF
--- a/slides/07/07.md
+++ b/slides/07/07.md
@@ -301,7 +301,7 @@ which is in fact one Newton-Raphson iteration step.
 Denoting $E_j ≝ y(→x_j) - t_j$, we can compute the first derivative as
 $$\frac{∂𝓛}{∂a_j} = t_j (E_i - E_j),$$
 and the second derivative as
-$$\frac{∂^2L}{∂a_j^2} = 2K(→x_i, →x_j) - K(→x_i, →x_i) - K(→x_j, →x_j).$$
+$$\frac{∂^2𝓛}{∂a_j^2} = 2K(→x_i, →x_j) - K(→x_i, →x_i) - K(→x_j, →x_j).$$
 
 ---
 # Sequential Minimal Optimization Update Rules


### PR DESCRIPTION
On slide 17 bottom there is a letter L written as normal instead of caligraphic.