### PR TITLE
Slides 08 | Fix "up to constant"

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -615,7 +615,7 @@ class: tablefull
 
 | | Discriminative Model | Generative Model |
 |-|----------------------|------------------|
-| Goal | Estimate $P(t\vert→x)$ | Estimate $P(t,→x) = P(→x\vert t) P(t)$ |
+| Goal | Estimate $P(t\vert→x)$ | Estimate $P(t,→x) ∝ P(→x\vert t) P(t)$ |
 | What's<br>learned | Decision boundary | Probability distribution of the data |
 | Illustration | ![w=100%](model_discriminative.png) | ![w=100%](model_generative.png) |
 


### PR DESCRIPTION
On slide 33 we estimate P(t | x) by Bayes theorem only up to constant (if I understand it correctly).