### PR TITLE
Fix missing slash in latex

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -174,8 +174,9 @@ $$→ȳ(→x; ⇉W)_i = \log(p(C_i | →x; ⇉W)) + c.$$
 The constant $c$ is present, because the output of the model is
 _overparametrized_ (for example, the probability of the last class could be
 computed from the remaining ones). This is connected to the fact that softmax
-is invariant to addition of a constant:
-$$softmax(→z + c)_i = \frac{e^{→z_i + c}}{∑_j e^{→z_j + c}} = \frac{e^{→z_i}}{∑_j e^{→z_j}}⋅\frac{e^c}{e^c} = \softmax(→z)_i.$$
+is
+ invariant to addition of a constant:
+$$\softmax(→z + c)_i = \frac{e^{→z_i + c}}{∑_j e^{→z_j + c}} = \frac{e^{→z_i}}{∑_j e^{→z_j}}⋅\frac{e^c}{e^c} = \softmax(→z)_i.$$
 
 ---
 # Multiclass Logistic Regression


### PR DESCRIPTION
Add `\` to `\softmax`.