### PR TITLE
Fix bound for perceptron convergence steps

### DIFF
--- a/slides/03/03.md
+++ b/slides/03/03.md
@@ -170,7 +170,7 @@ $$\cos(α) = \frac{→w_*^T →w_k}{\|→w_*\|⋅\|→w_k\|} ≥ \frac{kγ}{\sqr
 Therefore, the $\cos(α)$ increases during every update. Because the value of
 $\cos(α)$ is at most one, we can compute the upper bound on the number
 of steps when the algorithm converges as
-$$1 ≤ \frac{\sqrt{k}γ}{\sqrt{R^2}\|→w_*\|}\textrm{~or~}k ≥ \frac{R^2\|→w_*\|^2}{γ^2}.$$
+$$1 ≥ \frac{\sqrt{k}γ}{\sqrt{R^2}\|→w_*\|}\textrm{~or~}k ≤ \frac{R^2\|→w_*\|^2}{γ^2}.$$
 
 ---
 # Perceptron Issues


### PR DESCRIPTION
The comparison signs were incorrectly switched.