### PR TITLE
Fix indexer for 1-hot encoding of categorical outcomes

### DIFF
--- a/slides/03/03.md
+++ b/slides/03/03.md
@@ -215,7 +215,7 @@ discrete outcomes. It is parametrized by $→p ∈ [0, 1]^K$ such that $∑_{i=0
 ~~~
 We represent outcomes as vectors $∈ \{0, 1\}^K$ in the **one-hot encoding**.
 Therefore, an outcome $x ∈ \{0, 1, …, K-1\}$ is represented as a vector
-$$→1_x ≝ \big([i = x]\big)_{i=0}^{K-1} = \big(\underbrace{0, …, 0}_{k}, 1, \underbrace{0, …, 0}_{K-k-1}\big).$$
+$$→1_x ≝ \big([i = x]\big)_{k=0}^{K-1} = \big(\underbrace{0, …, 0}_{k}, 1, \underbrace{0, …, 0}_{K-k-1}\big).$$
 
 ~~~
 The outcome probability, mean, and variance are very similar to the Bernoulli


### PR DESCRIPTION
I believe the `k` describing the leading `0`'s in the one hot encoding corresponds to the index, which is denoted as `i` in the slide.