### PR TITLE
Clarify w* in "Proof of Perceptron Convergence"

### DIFF
--- a/slides/03/03.md
+++ b/slides/03/03.md
@@ -124,7 +124,7 @@ the learning rate matters there.
 class: dbend
 # Proof of Perceptron Convergence
 
-Let $→w_*$ be some weights separating the training data and let $→w_k$ be the
+Let $→w_*$ be some weights correctly classifying (separating) the training data and let $→w_k$ be the
 weights after $k$ non-trivial updates of the perceptron algorithm, with $→w_0$
 being 0.
 


### PR DESCRIPTION
I think it is clearer and straight-forward to say that weights "classify the train data correctly". "Separating the test data" might be harder to visualize if, in some sense, one doesn't already know the role of $w_*$ in the proof.