### PR TITLE
Tense correction + Precision-Recall formulation + typo

### DIFF
--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -378,7 +378,7 @@ $$\mathit{AM}(1\%, 100\%) = 50.5\%.$$
 
 ![w=60%,f=right](fscore_mean_geometric.svgz)
 
-Geometric mean of precision recall is
+Geometric mean of Precision-Recall is
 $$\mathit{GM}(p, r) ≝ \sqrt{p ⋅ r}.$$
 
 It is better than arithmetic mean, but still
@@ -389,7 +389,7 @@ $$\mathit{GM}(1\%, 100\%) = 10\%.$$
 
 ![w=60%,f=right](fscore_mean_harmonic.svgz)
 
-Harmonic mean of precision recall is
+Harmonic mean of Precision-Recall is
 $$\mathit{HM}(p, r) ≝ \frac{2}{\frac{1}{p} + \frac{1}{r}}.$$
 
 In addition to being bounded by the input values, $\mathit{HM}$ is also
@@ -424,7 +424,7 @@ instead of just $β$.
 
 ~~~
 Quoting C. J. van Rijsbergen from his book _Information Retrieval_, 1979:
-> _What we want is therefore a parameter $β$ to characterise the measurement function in such a way that we can say: it measures the effectiveness of retrieval with respect to a user who attaches $β$ times as much importance to recall as precision. The simplest way I know of quantifying this is to specify the $\recall/\precision$ ratio at which the user is willing to trade an increment in precision for an equal loss in recall._
+> _What we want is therefore a parameter $β$ to characterize the measurement function in such a way that we can say: it measures the effectiveness of retrieval with respect to a user who attaches $β$ times as much importance to recall as precision. The simplest way I know of quantifying this is to specify the $\recall/\precision$ ratio at which the user is willing to trade an increment in precision for an equal loss in recall._
 
 ~~~
 It is straightforward to verify that indeed $\frac{∂F_β}{∂\precision} = \frac{∂F_β}{∂\recall}$
@@ -485,7 +485,7 @@ in one of the following ways:
   locations in the input text.
 
 ~~~
-  - **accuracy** is artifically high, because many words are not a named entity;
+  - **accuracy** is artificially high, because many words are not a named entity;
 ~~~
   - **micro-averaged** $F_1$ consideres all named entities, with classes used
     only to decide if a prediction is correct;


### PR DESCRIPTION
In the sklearn documentation, the "Precision-Recall" term is used with the hyphen. See https://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html. Plus matching of s/z for American variant in the whole document.