### PR TITLE
Change `weighted` to `weighed`

### DIFF
--- a/slides/06/06.md
+++ b/slides/06/06.md
@@ -168,7 +168,7 @@ There exist quite a lot of kernels, but the most commonly used are the following
 
 Note that the RBF kernel is a function of distance – it "weighs" more similar
 examples more strongly. We could interpret it as an extended version of
-k-nearest neighbor algorithm, one which considers all examples, each weighted by
+k-nearest neighbor algorithm, one which considers all examples, each weighed by
 similarity.
 
 ~~~


### PR DESCRIPTION
"weighting" generally refers to adding or supplying weight to something, whereas "weighing" refers to determining the weight of something. I think we mean "weighed" in our context.