### PR TITLE
Import `sklearn.preprocessing` in labs/07/svm_multiclass.py

### DIFF
--- a/labs/07/svm_multiclass.py
+++ b/labs/07/svm_multiclass.py
@@ -5,6 +5,7 @@ import numpy as np
 import sklearn.datasets
 import sklearn.metrics
 import sklearn.model_selection
+import sklearn.preprocessing
 
 parser = argparse.ArgumentParser()
 # These arguments will be set appropriately by ReCodEx, even if you change them.


### PR DESCRIPTION
The script used `MinMaxScaler` without the import. 
I am curious how Python was able to find the `MinMaxScaler` without the import as the script ran just fine without the import.