### PR TITLE
Make multinomial NBC sum indexing more precise

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -558,13 +558,13 @@ $$p_{d,k}
 
 Denoting $n_{d, k}$ as the sum of features $x_d$ for a class $C_k$, the
 probabilities $p_{d, k}$ could be therefore estimated as
-$$p_{d, k} = \frac{n_{d, k}}{∑_j n_{j, k}}.$$
+$$p_{d, k} = \frac{n_{d, k}}{∑_{j = 1}^D n_{j, k}}.$$
 
 ~~~
 However, for the same reasons as in the Bernoulli NB case, we also use the
 Laplace smoothing, i.e., utilize a Dirichlet prior $\operatorname{Dir}(α+1)$,
 and instead use
-$$p_{d, k} = \frac{n_{d, k} + α}{∑_j (n_{j, k} + α)} = \frac{n_{d, k} + α}{\big(∑_j n_{j, k}\big) + αD} $$
+$$p_{d, k} = \frac{n_{d, k} + α}{∑_{j = 1}^D (n_{j, k} + α)} = \frac{n_{d, k} + α}{\big(∑_{j = 1}^D n_{j, k}\big) + αD} $$
 with pseudo-count $α > 0$.
 
 ---


### PR DESCRIPTION
$n_{d, k}$ denotes the sum of the `d-th` feature column of the examples from class $C_k$.
Using $j$ as the index - as $d$ was reserved - arguably makes it harder to unpack the sum. The explicit index bounds make the sum clearer.