### PR TITLE
ignore .xz archives

### DIFF
--- a/labs/.gitignore
+++ b/labs/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 logs/
 *.npz
 *.zip
+*.xz


### PR DESCRIPTION
Hi,

the current ignore policy contains zip archives. I figured that it might be useful to ignore xz archives as well.