### PR TITLE
disambiguate a formula

### DIFF
--- a/labs/10/gradient_boosting.py
+++ b/labs/10/gradient_boosting.py
@@ -36,7 +36,7 @@ def main(args: argparse.Namespace) -> tuple[list[float], list[float]]:
     # - the goal is to train `classes` regression trees, each predicting
     #   a part of logit for the corresponding class.
     # - compute the current predictions `y_{t-1}(x_i)` for every training example `i` as
-    #     y_{t-1}(x_i)_c = \sum_{i=1}^{t-1} args.learning_rate * tree_{iter=i,class=c}.predict(x_i)
+    #     y_{t-1}(x_i)_c = \sum_{j=1}^{t-1} args.learning_rate * tree_{iter=j,class=c}.predict(x_i)
     #     (note that y_0 is zero)
     # - loss in iteration `t` is
     #     E = (\sum_i NLL(onehot_target_i, softmax(y_{t-1}(x_i) + trees_to_train_in_iter_t.predict(x_i)))) +


### PR DESCRIPTION
Hi,

I was a little bit confused by one of the formulas in gradient_boosting due to an ambiguous index `i`, namely in subformula `tree_{iter=i, class=c}.predict(x_i)`; each occurrence of `i` is assumed to mean something else.

I've updated the file so the index is no longer ambiguous.

Best wishes,
JK