### PR TITLE
Adjustments to the text

### DIFF
--- a/slides/10/10.md
+++ b/slides/10/10.md
@@ -78,13 +78,13 @@ However, in some situations we can do better.
 ---
 # Newton’s Root-Finding Method
 
-Assume we have a function $f: ℝ → ℝ$ and we want to find its root. A SGD-like
+Assume we have a function $f: ℝ → ℝ$ and we want to find its root. An SGD-like
 algorithm would always move “towards” zero by taking small steps.
 
 ~~~
 ![w=40%,f=right](newton_iteration.svgz)
 
-Instead, we could consider the a linear local approximation
+Instead, we could consider the linear local approximation
 (i.e., consider a line “touching” the function in a given point)
 and perform a step so that our linear local approximation has
 a value 0:
@@ -113,7 +113,7 @@ The same update can be derived also from the Taylor’s expansion
 $$f(x + ε) ≈ f(x) + ε f'(x) + \frac{1}{2} ε^2 f''(x) \textcolor{gray}{+ 𝓞(ε^3)},$$
 
 ~~~
-which we can minimise for $ε$ by
+which we can minimize for $ε$ by
 $$0 = \frac{∂f(x + ε)}{∂ε} ≈ f'(x) + ε f''(x),\textrm{ ~obtaining~ }x + ε = x - \frac{f'(x)}{f''(x)}.$$
 
 ---
@@ -132,7 +132,7 @@ weights $→w ∈ ℝ^D$,
   $$H_{i,j} ≝ \frac{∂^2 E(→w)}{∂w_i ∂w_j}.$$
 
 ~~~
-For completeness, the Taylor expansion of a multivariate function than has the following form:
+For completeness, the Taylor expansion of a multivariate function then has the following form:
 $$f(→x + →ε) = f(→x) + →ε^T ∇f(→x) + \frac{1}{2} →ε^T ⇉H →ε,$$
 from which we obtain the following second-order method update:
 $$→x ← →x - ⇉H^{-1} ∇f(→x).$$


### PR DESCRIPTION
I've corrected several minor mistakes within the text:

- A SGD algorithm -> An SGD algorithm (it follows the first sound of SGD),
- A typo where "the a" appeared -> only one of them is correct,
- minimi**s**e -> minimi**z**e - here, it's not a mistake, yet only the American type with "z" have been used throughout the text and this was the only exemption,
- than -> then is a typo.

Have a great day!