### PR TITLE
L2 regularization as MAP

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -234,7 +234,7 @@ $$\begin{aligned}
 ~~~
 
 By substituting the probability of the Gaussian prior, we get
-$$→w_\mathrm{MAP} = \argmin_{→w} ∑\nolimits_{i=1}^N \Big(-\log p(→x_i | →w) {\color{gray} - \frac{D}{2} \log(2πσ^2)} + \frac{\|→w\|^2}{2σ^2}\Big),$$
+$$→w_\mathrm{MAP} = \argmin_{→w} ∑\nolimits_{i=1}^N \Big(-\log p(→x_i | →w) {\color{gray} + \frac{D}{2} \log(2πσ^2)} + \frac{\|→w\|^2}{2σ^2}\Big),$$
 
 which is in fact the $L^2$-regularization.
 


### PR DESCRIPTION
The [8<sup>th</sup> presentation](https://ufal.mff.cuni.cz/~straka/courses/npfl129/2223/slides/?08#45) states that

$$
  \boldsymbol w_{\text{MAP}} = \underset{\boldsymbol w}{\operatorname{arg\\,min}} \sum_{i=1}^N \Bigl(
    -\log p(\boldsymbol x_i \mid \boldsymbol w) - \frac{D}{2} \log(2\pi\sigma^2) + \frac{\\|\boldsymbol w\\|^2}{2\sigma^2}
  \Bigr)\text{.}
$$

However, after manual computation, I think there should be $+\frac{D}{2} \log(2\pi\sigma^2)$.

---

Given that

$$
  p(\boldsymbol w) = \prod_{i=1}^D \frac{1}{\sqrt{2\pi\sigma^2}} \exp\Bigl(-\frac{w_i^2}{2\sigma^2}\Bigr)\text{,}
$$

_maximum a posteriori_ estimate can be expressed as follows:

$$
  \begin{aligned}
    \boldsymbol w_{\text{MAP}}
    &= \underset{\boldsymbol w}{\operatorname{arg\\,max}}\  p(\boldsymbol X \mid \boldsymbol w) p(\boldsymbol w) = \\
    &= \underset{\boldsymbol w}{\operatorname{arg\\,max}} \prod_{i=1}^N p(\boldsymbol x_i \mid \boldsymbol w) p(\boldsymbol w) = \\
    &= \underset{\boldsymbol w}{\operatorname{arg\\,min}} \sum_{i=1}^N \left( -\log p(\boldsymbol x_i \mid \boldsymbol w) -\log p(\boldsymbol w) \right) = \\
    &= \underset{\boldsymbol w}{\operatorname{arg\\,min}} \sum_{i=1}^N \left( -\log p(\boldsymbol x_i \mid \boldsymbol w) - \sum_{j=1}^D \log \biggl( \frac{1}{\sqrt{2\pi\sigma^2}} \exp\Bigl(-\frac{w_i^2}{2\sigma^2}\Bigr) \biggr) \right) = \\
    &= \underset{\boldsymbol w}{\operatorname{arg\\,min}} \sum_{i=1}^N \left( -\log p(\boldsymbol x_i \mid \boldsymbol w) - \sum_{j=1}^D \log \biggl( \frac{1}{\sqrt{2\pi\sigma^2}} \biggr) - \sum_{j=1}^D \log \biggl( \exp\Bigl(-\frac{w_i^2}{2\sigma^2}\Bigr) \biggr) \right) = \\
    &= \underset{\boldsymbol w}{\operatorname{arg\\,min}} \sum_{i=1}^N \left( -\log p(\boldsymbol x_i \mid \boldsymbol w) - \frac{D}{2} \log \biggl( \frac{1}{2\pi\sigma^2} \biggr) + \frac{\\|w\\|^2}{2\sigma^2} \right) = \\
    &= \underset{\boldsymbol w}{\operatorname{arg\\,min}} \sum_{i=1}^N \left( -\log p(\boldsymbol x_i \mid \boldsymbol w) + \frac{D}{2} \log \bigl( 2\pi\sigma^2 \bigr) + \frac{\\|w\\|^2}{2\sigma^2} \right)
  \end{aligned}
$$