### PR TITLE
Use consistent font for random variables

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -59,14 +59,14 @@ Consider two random variables $⁇x$ and $⁇y$ with distributions $⁇x ∼ X$ 
 The conditional entropy $H(Y | X)$ can be naturally considered an expectation of
 a self-information of $Y | X$, so in the discrete case,
 ~~~
-$$H(Y | X) = 𝔼_{x,y} \big[I(y|x)\big] = -∑_{x,y} P(x, y) \log P(y | x).$$
+$$H(Y | X) = 𝔼_{⁇x,⁇y} \big[I(y|x)\big] = -∑_{x,y} P(x, y) \log P(y | x).$$
 
 ~~~
 In order to assess the amount of information _shared_ between the two
 random variables, we might consider the difference
 $$\textcolor{red}{H(Y)} - \textcolor{blue}{H(Y | X)}
-  = 𝔼_{x,y} \big[\textcolor{red}{-\log P(y)}\big] - 𝔼_{x,y} \big[\textcolor{blue}{-\log P(y|x)}\big]
-  = 𝔼_{x,y} \left[\log\frac{\textcolor{blue}{P(x, y)}}{\textcolor{blue}{P(x)} \textcolor{red}{P(y)}}\right].$$
+  = 𝔼_{⁇x,⁇y} \big[\textcolor{red}{-\log P(y)}\big] - 𝔼_{⁇x,⁇y} \big[\textcolor{blue}{-\log P(y|x)}\big]
+  = 𝔼_{⁇x,⁇y} \left[\log\frac{\textcolor{blue}{P(x, y)}}{\textcolor{blue}{P(x)} \textcolor{red}{P(y)}}\right].$$
 
 ~~~
 We can interpret this value as
@@ -79,7 +79,7 @@ We can interpret this value as
 ![w=27%,f=right](mutual_information.svgz)
 
 Let us denote this quantity as the **mutual information** $I(X; Y)$:
-$$I(X; Y) = 𝔼_{x,y} \left[\log\frac{P(x, y)}{P(x)P(y)}\right].$$
+$$I(X; Y) = 𝔼_{⁇x,⁇y} \left[\log\frac{P(x, y)}{P(x)P(y)}\right].$$
 
 ~~~
 - The mutual information is symmetrical, so


### PR DESCRIPTION
The font of $\mathbb{E}$'s index in the 8<sup>th</sup> presentation was changed to match the notation used in the [definition of expectation](https://ufal.mff.cuni.cz/~straka/courses/npfl129/2223/slides/?02#69) (so that it's really expectation of _a random variable_).