### PR TITLE
Proposition: use conditional probability when comparing gen-disc pair

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -656,7 +656,7 @@ class: tablefull
 # LogReg/NaiveBayes Generative-Discriminative Pair
 
 Given that
-- multinomial/Bernoulli naive Bayes fits $\log p(C_k, →x)$ as a linear model, and
+- multinomial/Bernoulli naive Bayes fits $\log p(C_k | →x)$ as a linear model, and
 ~~~
 - a logistic regression also fits $\log p(C_k | →x)$ as a linear model,
 


### PR DESCRIPTION
I think it makes more sense to use conditional instead of joint probability in this case as the linearness (of the conditional probability) was shown earlier on the slides and it makes comparison clearer.