### PR TITLE
Change feature_engineering.py OneHotEncoder comment

### DIFF
--- a/labs/02/feature_engineering.py
+++ b/labs/02/feature_engineering.py
@@ -31,7 +31,7 @@ def main(args: argparse.Namespace) -> tuple[np.ndarray, np.ndarray]:
     #   represent numerical non-categorical values, but we use this assumption
     #   for the sake of exercise). Encode the values with one-hot encoding
     #   using `sklearn.preprocessing.OneHotEncoder` (note that its output is by
-    #   default sparse, you can use `sparse=False` to generate dense output;
+    #   default sparse, you can use `sparse_output=False` to generate dense output;
     #   also use `handle_unknown="ignore"` to ignore missing values in test set).
     #
     # - for the rest of the columns, normalize their values so that they


### PR DESCRIPTION
This happens to me when using `sparse=False` instead of `sparse_output=False`. I believe that `sparse` has been deprecated in favor of `sparse_output`, according to the docs.

```python
sklearn.preprocessing.OneHotEncoder(sparse=False, handle_unknown="ignore")
TypeError: OneHotEncoder.__init__() got an unexpected keyword argument 'sparse'
```